### PR TITLE
v3.3.9 Release

### DIFF
--- a/Ana/Ana.csproj
+++ b/Ana/Ana.csproj
@@ -307,6 +307,7 @@
     <Compile Include="Source\Snapshots\SnapshotElementRef.cs" />
     <Compile Include="Source\Utils\Compression.cs" />
     <Compile Include="Source\Utils\DataStructures\BiDictionary.cs" />
+    <Compile Include="Source\Utils\Extensions\StringExtensions.cs" />
     <Compile Include="Source\Utils\Hashing.cs" />
     <Compile Include="Source\Utils\TypeEditors\HotkeyEditor\HotkeyEditorViewModel.cs" />
     <Compile Include="Source\Utils\TypeEditors\HotkeyEditor\HotkeyEditorModel.cs" />

--- a/Ana/Ana.csproj
+++ b/Ana/Ana.csproj
@@ -31,11 +31,11 @@
     <ErrorReportUrl>https://www.anathena.com/</ErrorReportUrl>
     <ProductName>Anathena</ProductName>
     <PublisherName>Anathena</PublisherName>
-    <MinimumRequiredVersion>3.3.8.0</MinimumRequiredVersion>
+    <MinimumRequiredVersion>3.3.9.0</MinimumRequiredVersion>
     <CreateWebPageOnPublish>true</CreateWebPageOnPublish>
     <WebPage>publish.htm</WebPage>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>3.3.8.0</ApplicationVersion>
+    <ApplicationVersion>3.3.9.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <CreateDesktopShortcut>true</CreateDesktopShortcut>
     <PublishWizardCompleted>true</PublishWizardCompleted>

--- a/Ana/Content/Templates/CodeInjectionTemplate.cs
+++ b/Ana/Content/Templates/CodeInjectionTemplate.cs
@@ -35,7 +35,7 @@ using Ana.Source.ScriptEngine.Hook;
 using Ana.Source.ScriptEngine.Input;
 using Ana.Source.ScriptEngine.Memory;
 
-public class Test
+public class Cheat
 {
 	// Engine to provide access to memory, graphics, input, etc
 	private ScriptEngine Engine = new ScriptEngine();
@@ -54,7 +54,7 @@ public class Test
 		Memory.SetKeyword(""exit"", Memory.GetCaveExitAddress(entry));
 		
 		var code = @""
-			jmp exit
+			jmp <exit>
 			"";
 		
 		Memory.CreateCodeCave(entry, code);

--- a/Ana/Content/Templates/CodeInjectionTemplate.cs
+++ b/Ana/Content/Templates/CodeInjectionTemplate.cs
@@ -50,11 +50,11 @@ public class Cheat
 	
 	public void OnActivate()
 	{
-		var entry = Memory.GetModuleAddress(""moduleName"") + 0x1234;
-		Memory.SetKeyword(""exit"", Memory.GetCaveExitAddress(entry));
+		var moduleBase = Memory.GetModuleAddress(""moduleName"");
+		var entry = moduleBase + 0x1234;
 		
 		var code = @""
-			jmp <exit>
+			nop
 			"";
 		
 		Memory.CreateCodeCave(entry, code);

--- a/Ana/Content/Templates/CodeInjectionTemplate.tt
+++ b/Ana/Content/Templates/CodeInjectionTemplate.tt
@@ -25,11 +25,11 @@ public class Cheat
 	
 	public void OnActivate()
 	{
-		var entry = Memory.GetModuleAddress("moduleName") + 0x1234;
-		Memory.SetKeyword("exit", Memory.GetCaveExitAddress(entry));
+		var moduleBase = Memory.GetModuleAddress("moduleName");
+		var entry = moduleBase + 0x1234;
 		
 		var code = @"
-			jmp <exit>
+			nop
 			";
 		
 		Memory.CreateCodeCave(entry, code);

--- a/Ana/Content/Templates/CodeInjectionTemplate.tt
+++ b/Ana/Content/Templates/CodeInjectionTemplate.tt
@@ -10,7 +10,7 @@ using Ana.Source.ScriptEngine.Hook;
 using Ana.Source.ScriptEngine.Input;
 using Ana.Source.ScriptEngine.Memory;
 
-public class Test
+public class Cheat
 {
 	// Engine to provide access to memory, graphics, input, etc
 	private ScriptEngine Engine = new ScriptEngine();
@@ -29,7 +29,7 @@ public class Test
 		Memory.SetKeyword("exit", Memory.GetCaveExitAddress(entry));
 		
 		var code = @"
-			jmp exit
+			jmp <exit>
 			";
 		
 		Memory.CreateCodeCave(entry, code);

--- a/Ana/Properties/AssemblyInfo.cs
+++ b/Ana/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.3.8.0")]
-[assembly: AssemblyFileVersion("3.3.8.0")]
+[assembly: AssemblyVersion("3.3.9.0")]
+[assembly: AssemblyFileVersion("3.3.9.0")]

--- a/Ana/Source/Controls/HexDecBoxViewModel.cs
+++ b/Ana/Source/Controls/HexDecBoxViewModel.cs
@@ -55,11 +55,11 @@
 
                 if (this.IsDec && CheckSyntax.IsUInt64(rawValue))
                 {
-                    this.value = Conversions.ParseDecStringAsValue(typeof(UInt64), rawValue);
+                    this.value = Conversions.ParsePrimitiveStringAsDynamic(typeof(UInt64), rawValue);
                 }
                 else if (this.IsHex && CheckSyntax.CanParseHex(typeof(UInt64), rawValue))
                 {
-                    this.value = Conversions.ParseHexStringAsValue(typeof(UInt64), rawValue);
+                    this.value = Conversions.ParseHexStringAsDynamic(typeof(UInt64), rawValue);
                 }
 
                 return this.value;

--- a/Ana/Source/Engine/Architecture/Assembler/Fasm32Assembler.cs
+++ b/Ana/Source/Engine/Architecture/Assembler/Fasm32Assembler.cs
@@ -5,16 +5,16 @@
     using Utils.Extensions;
 
     /// <summary>
-    /// The Fasm assembler for x86/64
+    /// The Fasm assembler for x86/64.
     /// </summary>
     internal class Fasm32Assembler : IAssembler
     {
         /// <summary>
-        /// Assemble the specified assembly code
+        /// Assemble the specified assembly code.
         /// </summary>
-        /// <param name="isProcess32Bit">Whether or not the assembly is in the context of a 32 bit program</param>
-        /// <param name="assembly">The assembly code</param>
-        /// <returns>An array of bytes containing the assembly code</returns>
+        /// <param name="isProcess32Bit">Whether or not the assembly is in the context of a 32 bit program.</param>
+        /// <param name="assembly">The assembly code.</param>
+        /// <returns>An array of bytes containing the assembly code.</returns>
         public Byte[] Assemble(Boolean isProcess32Bit, String assembly)
         {
             // Assemble and return the code
@@ -22,16 +22,17 @@
         }
 
         /// <summary>
-        /// Assemble the specified assembly code at a base address
+        /// Assemble the specified assembly code at a base address.
         /// </summary>
-        /// <param name="isProcess32Bit">Whether or not the assembly is in the context of a 32 bit program</param>
+        /// <param name="isProcess32Bit">Whether or not the assembly is in the context of a 32 bit program.</param>
         /// <param name="assembly">The assembly code.</param>
-        /// <param name="baseAddress">The address where the code is rebased</param>
+        /// <param name="baseAddress">The address where the code is rebased.</param>
         /// <returns>An array of bytes containing the assembly code.</returns>
         public Byte[] Assemble(Boolean isProcess32Bit, String assembly, IntPtr baseAddress)
         {
             // Call proxy service, which simply passes the asm code to Fasm.net to assemble the instructions
-            return ProxyCommunicator.GetInstance().GetProxyService(isProcess32Bit).Assemble(isProcess32Bit, assembly, baseAddress.ToUInt64());
+            // Note: for assembling instructions, we must always use the 32-bit proxy service to assemble both x86/x64 instructions
+            return ProxyCommunicator.GetInstance().GetProxyService(true).Assemble(isProcess32Bit, assembly, baseAddress.ToUInt64());
         }
     }
     //// End class

--- a/Ana/Source/Engine/OperatingSystems/IOperatingSystemAdapter.cs
+++ b/Ana/Source/Engine/OperatingSystems/IOperatingSystemAdapter.cs
@@ -57,6 +57,14 @@
         IntPtr AllocateMemory(Int32 size);
 
         /// <summary>
+        /// Allocates memory in the opened process
+        /// </summary>
+        /// <param name="size">The size of the memory allocation</param>
+        /// <param name="allocAddress">The rough address of where the allocation should take place.</param>
+        /// <returns>A pointer to the location of the allocated memory</returns>
+        IntPtr AllocateMemory(Int32 size, IntPtr allocAddress);
+
+        /// <summary>
         /// Deallocates memory in the opened process
         /// </summary>
         /// <param name="address">The address to perform the region wide deallocation</param>

--- a/Ana/Source/Engine/OperatingSystems/Windows/WindowsAdapter.cs
+++ b/Ana/Source/Engine/OperatingSystems/Windows/WindowsAdapter.cs
@@ -462,30 +462,37 @@
             IntPtr[] modulePointers = new IntPtr[0];
             Int32 bytesNeeded = 0;
 
-            // Determine number of modules
-            if (!Native.NativeMethods.EnumProcessModulesEx(systemProcess.Handle, modulePointers, 0, out bytesNeeded, (UInt32)Enumerations.ModuleFilter.ListModulesAll))
+            try
             {
-                return normalizedModules;
-            }
-
-            Int32 totalNumberofModules = bytesNeeded / IntPtr.Size;
-            modulePointers = new IntPtr[totalNumberofModules];
-
-            if (Native.NativeMethods.EnumProcessModulesEx(systemProcess.Handle, modulePointers, bytesNeeded, out bytesNeeded, (UInt32)Enumerations.ModuleFilter.ListModulesAll))
-            {
-                for (Int32 index = 0; index < totalNumberofModules; index++)
+                // Determine number of modules
+                if (!Native.NativeMethods.EnumProcessModulesEx(systemProcess.Handle, modulePointers, 0, out bytesNeeded, (UInt32)Enumerations.ModuleFilter.ListModulesAll))
                 {
-                    StringBuilder moduleFilePath = new StringBuilder(1024);
-                    Native.NativeMethods.GetModuleFileNameEx(systemProcess.Handle, modulePointers[index], moduleFilePath, (UInt32)(moduleFilePath.Capacity));
-
-                    String moduleName = Path.GetFileName(moduleFilePath.ToString());
-                    ModuleInformation moduleInformation = new ModuleInformation();
-                    Native.NativeMethods.GetModuleInformation(systemProcess.Handle, modulePointers[index], out moduleInformation, (UInt32)(IntPtr.Size * (modulePointers.Length)));
-
-                    // Convert to a normalized module and add it to our list
-                    NormalizedModule module = new NormalizedModule(moduleName, moduleInformation.lpBaseOfDll, unchecked((Int32)moduleInformation.SizeOfImage));
-                    normalizedModules.Add(module);
+                    return normalizedModules;
                 }
+
+                Int32 totalNumberofModules = bytesNeeded / IntPtr.Size;
+                modulePointers = new IntPtr[totalNumberofModules];
+
+                if (Native.NativeMethods.EnumProcessModulesEx(systemProcess.Handle, modulePointers, bytesNeeded, out bytesNeeded, (UInt32)Enumerations.ModuleFilter.ListModulesAll))
+                {
+                    for (Int32 index = 0; index < totalNumberofModules; index++)
+                    {
+                        StringBuilder moduleFilePath = new StringBuilder(1024);
+                        Native.NativeMethods.GetModuleFileNameEx(systemProcess.Handle, modulePointers[index], moduleFilePath, (UInt32)(moduleFilePath.Capacity));
+
+                        String moduleName = Path.GetFileName(moduleFilePath.ToString());
+                        ModuleInformation moduleInformation = new ModuleInformation();
+                        Native.NativeMethods.GetModuleInformation(systemProcess.Handle, modulePointers[index], out moduleInformation, (UInt32)(IntPtr.Size * (modulePointers.Length)));
+
+                        // Convert to a normalized module and add it to our list
+                        NormalizedModule module = new NormalizedModule(moduleName, moduleInformation.lpBaseOfDll, unchecked((Int32)moduleInformation.SizeOfImage));
+                        normalizedModules.Add(module);
+                    }
+                }
+            }
+            catch
+            {
+                // TODO: Log to user
             }
 
             return normalizedModules;
@@ -580,9 +587,17 @@
                 return true;
             }
 
-            Process systemProcess = Process.GetProcessById(process.ProcessId);
+            try
+            {
+                Process systemProcess = Process.GetProcessById(process.ProcessId);
 
-            if (systemProcess == null || !Native.NativeMethods.IsWow64Process(systemProcess.Handle, out isWow64))
+                if (systemProcess == null || !Native.NativeMethods.IsWow64Process(systemProcess.Handle, out isWow64))
+                {
+                    // Error, assume 32 bit
+                    return true;
+                }
+            }
+            catch
             {
                 // Error, assume 32 bit
                 return true;

--- a/Ana/Source/Engine/OperatingSystems/Windows/WindowsAdapter.cs
+++ b/Ana/Source/Engine/OperatingSystems/Windows/WindowsAdapter.cs
@@ -462,7 +462,14 @@
                 return normalizedModules;
             }
 
-            Process systemProcess = Process.GetProcessById(process.ProcessId);
+            try
+            {
+                Process systemProcess = Process.GetProcessById(process.ProcessId);
+            }
+            catch
+            {
+                return normalizedModules;
+            }
 
             if (systemProcess == null)
             {

--- a/Ana/Source/Engine/OperatingSystems/Windows/WindowsAdapter.cs
+++ b/Ana/Source/Engine/OperatingSystems/Windows/WindowsAdapter.cs
@@ -318,7 +318,18 @@
         /// <returns>A pointer to the location of the allocated memory</returns>
         public IntPtr AllocateMemory(Int32 size)
         {
-            return Memory.Allocate(this.SystemProcess == null ? IntPtr.Zero : this.SystemProcess.Handle, size);
+            return Memory.Allocate(this.SystemProcess == null ? IntPtr.Zero : this.SystemProcess.Handle, IntPtr.Zero, size);
+        }
+
+        /// <summary>
+        /// Allocates memory in the opened process
+        /// </summary>
+        /// <param name="size">The size of the memory allocation</param>
+        /// <param name="allocAddress">The rough address of where the allocation should take place.</param>
+        /// <returns>A pointer to the location of the allocated memory</returns>
+        public IntPtr AllocateMemory(Int32 size, IntPtr allocAddress)
+        {
+            return Memory.Allocate(this.SystemProcess == null ? IntPtr.Zero : this.SystemProcess.Handle, allocAddress, size);
         }
 
         /// <summary>

--- a/Ana/Source/MVVM/Converters/Int32ToHexConverter.cs
+++ b/Ana/Source/MVVM/Converters/Int32ToHexConverter.cs
@@ -27,7 +27,7 @@
 
             if (value is Int32)
             {
-                return Conversions.ParseValueAsHex(typeof(Int32), value);
+                return Conversions.ParseDynamicAsHex(typeof(Int32), value);
             }
 
             return String.Empty;
@@ -52,7 +52,7 @@
             {
                 if (CheckSyntax.CanParseHex(typeof(Int32), value.ToString()))
                 {
-                    return Conversions.ParseHexStringAsValue(typeof(Int32), value.ToString());
+                    return Conversions.ParseHexStringAsDynamic(typeof(Int32), value.ToString());
                 }
             }
 

--- a/Ana/Source/MVVM/Converters/IntPtrToAddressConverter.cs
+++ b/Ana/Source/MVVM/Converters/IntPtrToAddressConverter.cs
@@ -27,7 +27,7 @@
 
             if (value is IntPtr)
             {
-                return Conversions.ToAddress((IntPtr)value);
+                return Conversions.ToHex((IntPtr)value);
             }
 
             return null;

--- a/Ana/Source/Project/ProjectItems/AddressItem.cs
+++ b/Ana/Source/Project/ProjectItems/AddressItem.cs
@@ -83,7 +83,7 @@
 
             if (!this.isValueHex && CheckSyntax.CanParseValue(elementType, value))
             {
-                this.addressValue = Utils.Validation.Conversions.ParseDecStringAsValue(elementType, value);
+                this.addressValue = Utils.Validation.Conversions.ParsePrimitiveStringAsDynamic(elementType, value);
             }
             else if (this.isValueHex && CheckSyntax.CanParseHex(elementType, value))
             {
@@ -271,10 +271,10 @@
         {
             if (this.Offsets != null && this.Offsets.Count() > 0)
             {
-                return "P->" + Conversions.ToAddress(this.EffectiveAddress);
+                return "P->" + Conversions.ToHex(this.EffectiveAddress);
             }
 
-            return Conversions.ToAddress(this.EffectiveAddress);
+            return Conversions.ToHex(this.EffectiveAddress);
         }
 
         /// <summary>

--- a/Ana/Source/Project/ProjectItems/AddressItem.cs
+++ b/Ana/Source/Project/ProjectItems/AddressItem.cs
@@ -310,13 +310,16 @@
             {
                 case AddressResolver.ResolveTypeEnum.Module:
                     pointer = AddressResolver.GetInstance().ResolveModule(this.BaseIdentifier);
-                    pointer = pointer.Add(this.BaseAddress);
+                    break;
+                case AddressResolver.ResolveTypeEnum.GlobalKeyword:
+                    pointer = AddressResolver.GetInstance().ResolveGlobalKeyword(this.BaseIdentifier);
                     break;
                 case AddressResolver.ResolveTypeEnum.DotNet:
                     pointer = AddressResolver.GetInstance().ResolveDotNetObject(this.BaseIdentifier);
-                    pointer = pointer.Add(this.BaseAddress);
                     break;
             }
+
+            pointer = pointer.Add(this.BaseAddress);
 
             if (this.Offsets == null || this.Offsets.Count() == 0)
             {

--- a/Ana/Source/Scanners/PointerScanner/PointerScannerModel.cs
+++ b/Ana/Source/Scanners/PointerScanner/PointerScannerModel.cs
@@ -164,7 +164,7 @@
 
         public String GetAddressAtIndex(Int32 index)
         {
-            return Conversions.ToAddress(this.AcceptedPointers[index].Item1);
+            return Conversions.ToHex(this.AcceptedPointers[index].Item1);
         }
 
         public IEnumerable<String> GetOffsetsAtIndex(Int32 index)

--- a/Ana/Source/ScriptEngine/Memory/IMemoryCore.cs
+++ b/Ana/Source/ScriptEngine/Memory/IMemoryCore.cs
@@ -36,9 +36,9 @@
         /// next instruction.
         /// </summary>
         /// <param name="address">The base address to begin reading instructions.</param>
-        /// <param name="minimumInstructionBytes">The minimum number of bytes the instructions must take.</param>
+        /// <param name="injectedCodeSize">The size of the code being injected.</param>
         /// <returns>The bytes read from memory.</returns>
-        Byte[] GetInstructionBytes(UInt64 address, Int32 minimumInstructionBytes);
+        Byte[] CollectOriginalBytes(UInt64 address, Int32 injectedCodeSize);
 
         /// <summary>
         /// Allocates memory in the target process, and returns the address of the new memory.
@@ -106,6 +106,20 @@
         /// <param name="globalKeyword">The global keyword to bind.</param>
         /// <param name="address">The address to which the keyword is bound.</param>
         void SetGlobalKeyword(String globalKeyword, UInt64 address);
+
+        /// <summary>
+        /// Gets the value of a keyword.
+        /// </summary>
+        /// <param name="keyword">The keyword.</param>
+        /// <returns>The value of the keyword. If not found, returns 0.</returns>
+        UInt64 GetKeywordValue(String keyword);
+
+        /// <summary>
+        /// Gets the value of a global keyword.
+        /// </summary>
+        /// <param name="keyword">The global keyword.</param>
+        /// <returns>The value of the global keyword. If not found, returns 0.</returns>
+        UInt64 GetGlobalKeywordValue(String globalKeyword);
 
         /// <summary>
         /// Clears the specified keyword created by the parent script.

--- a/Ana/Source/ScriptEngine/Memory/IMemoryCore.cs
+++ b/Ana/Source/ScriptEngine/Memory/IMemoryCore.cs
@@ -48,6 +48,14 @@
         UInt64 AllocateMemory(Int32 size);
 
         /// <summary>
+        /// Allocates memory in the target process, and returns the address of the new memory.
+        /// </summary>
+        /// <param name="size">The size of the allocation.</param>
+        /// <param name="allocAddress">The rough address of where the allocation should take place.</param>
+        /// <returns>The address of the allocated memory.</returns>
+        UInt64 AllocateMemory(Int32 size, IntPtr allocAddress);
+
+        /// <summary>
         /// Deallocates memory previously allocated at a specified address.
         /// </summary>
         /// <param name="address">The address to perform the deallocation.</param>

--- a/Ana/Source/ScriptEngine/Memory/MemoryCore.cs
+++ b/Ana/Source/ScriptEngine/Memory/MemoryCore.cs
@@ -639,12 +639,12 @@
             // Resolve keywords
             foreach (KeyValuePair<String, String> keyword in this.Keywords)
             {
-                assembly = assembly.Replace("<" + keyword.Key + ">", keyword.Value);
+                assembly = assembly.Replace("<" + keyword.Key + ">", keyword.Value, StringComparison.OrdinalIgnoreCase);
             }
 
             foreach (KeyValuePair<String, String> globalKeyword in MemoryCore.globalKeywords.Value.ToArray())
             {
-                assembly = assembly.Replace("<" + globalKeyword.Key + ">", globalKeyword.Value);
+                assembly = assembly.Replace("<" + globalKeyword.Key + ">", globalKeyword.Value, StringComparison.OrdinalIgnoreCase);
             }
 
             return assembly;

--- a/Ana/Source/SignatureCollector/SignatureModel.cs
+++ b/Ana/Source/SignatureCollector/SignatureModel.cs
@@ -5,6 +5,7 @@
     using System.Runtime.Serialization;
     using System.Runtime.Serialization.Json;
     using System.Text;
+
     [DataContract]
     internal class SignatureModel
     {
@@ -52,6 +53,15 @@
             String base64Signature = Convert.ToBase64String(bytes);
 
             return base64Signature;
+        }
+
+        public static SignatureModel Deserialize(String base64Signature)
+        {
+            Byte[] bytes = Convert.FromBase64String(base64Signature);
+            MemoryStream memoryStream = new MemoryStream(bytes);
+            DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(SignatureModel));
+            SignatureModel signature = (SignatureModel)serializer.ReadObject(memoryStream);
+            return signature;
         }
     }
     //// End class

--- a/Ana/Source/Utils/Extensions/StringExtensions.cs
+++ b/Ana/Source/Utils/Extensions/StringExtensions.cs
@@ -1,7 +1,7 @@
 ﻿namespace Ana.Source.Utils.Extensions
 {
     using System;
-
+    using System.Text;
     internal static class StringExtensions
     {
         public static String RemoveSuffixes(this String str, params String[] suffixes)
@@ -27,6 +27,28 @@
             }
 
             return str.Substring(0, str.Length - suffix.Length);
+        }
+
+        public static String Replace(this String source, String oldValue, String newValue, StringComparison comparisonType)
+        {
+            if (source.Length == 0 || oldValue.Length == 0)
+            {
+                return source;
+            }
+
+            StringBuilder result = new StringBuilder();
+            Int32 startingPos = 0;
+            Int32 nextMatch;
+
+            while ((nextMatch = source.IndexOf(oldValue, startingPos, comparisonType)) > -1)
+            {
+                result.Append(source, startingPos, nextMatch - startingPos);
+                result.Append(newValue);
+                startingPos = nextMatch + oldValue.Length;
+            }
+            result.Append(source, startingPos, source.Length - startingPos);
+
+            return result.ToString();
         }
     }
     //// End class

--- a/Ana/Source/Utils/Extensions/StringExtensions.cs
+++ b/Ana/Source/Utils/Extensions/StringExtensions.cs
@@ -1,7 +1,7 @@
 ﻿namespace Ana.Source.Utils.Extensions
 {
     using System;
-    using System.Linq;
+
     internal static class StringExtensions
     {
         public static String RemoveSuffixes(this String str, params String[] suffixes)
@@ -27,13 +27,6 @@
             }
 
             return str.Substring(0, str.Length - suffix.Length);
-        }
-
-        public static String TrimWhiteSpace(this String input)
-        {
-            return new String(input.ToCharArray()
-                .Where(c => !Char.IsWhiteSpace(c))
-                .ToArray());
         }
     }
     //// End class

--- a/Ana/Source/Utils/Extensions/StringExtensions.cs
+++ b/Ana/Source/Utils/Extensions/StringExtensions.cs
@@ -1,7 +1,7 @@
 ﻿namespace Ana.Source.Utils.Extensions
 {
     using System;
-
+    using System.Linq;
     internal static class StringExtensions
     {
         public static String RemoveSuffixes(this String str, params String[] suffixes)
@@ -27,6 +27,13 @@
             }
 
             return str.Substring(0, str.Length - suffix.Length);
+        }
+
+        public static String TrimWhiteSpace(this String input)
+        {
+            return new String(input.ToCharArray()
+                .Where(c => !Char.IsWhiteSpace(c))
+                .ToArray());
         }
     }
     //// End class

--- a/Ana/Source/Utils/Extensions/StringExtensions.cs
+++ b/Ana/Source/Utils/Extensions/StringExtensions.cs
@@ -1,0 +1,34 @@
+﻿namespace Ana.Source.Utils.Extensions
+{
+    using System;
+
+    internal static class StringExtensions
+    {
+        public static String RemoveSuffixes(this String str, params String[] suffixes)
+        {
+            if (suffixes == null)
+            {
+                return str;
+            }
+
+            String suffix = String.Empty;
+            foreach (String nextSuffix in suffixes)
+            {
+                if (str.EndsWith(nextSuffix))
+                {
+                    suffix = nextSuffix;
+                    break;
+                }
+            }
+
+            if (String.IsNullOrEmpty(suffix))
+            {
+                return str;
+            }
+
+            return str.Substring(0, str.Length - suffix.Length);
+        }
+    }
+    //// End class
+}
+//// End namespace

--- a/Ana/Source/Utils/TypeConverters/AddressConverter.cs
+++ b/Ana/Source/Utils/TypeConverters/AddressConverter.cs
@@ -23,7 +23,7 @@
         {
             if (CheckSyntax.CanParseValue(typeof(UInt64), value.ToString()))
             {
-                return Conversions.ToAddress(Conversions.ParseDecStringAsValue(typeof(UInt64), value.ToString()));
+                return Conversions.ToHex(Conversions.ParsePrimitiveStringAsDynamic(typeof(UInt64), value.ToString()));
             }
 
             return base.ConvertTo(context, culture, value, destinationType);

--- a/Ana/Source/Utils/TypeConverters/DynamicConverter.cs
+++ b/Ana/Source/Utils/TypeConverters/DynamicConverter.cs
@@ -35,7 +35,7 @@
                 return base.ConvertTo(context, culture, value, destinationType);
             }
 
-            return isHex ? Conversions.ParseValueAsHex(valueType, valueString) : Conversions.ParseValueAsDec(valueType, valueString);
+            return isHex ? Conversions.ParseDynamicAsHex(valueType, valueString) : Conversions.ParseDynamicAsPrimitiveString(valueType, valueString);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@
                 return base.ConvertFrom(context, culture, value);
             }
 
-            return isHex ? Conversions.ParseHexStringAsValue(valueType, value as String) : Conversions.ParseDecStringAsValue(valueType, value as String);
+            return isHex ? Conversions.ParseHexStringAsDynamic(valueType, value as String) : Conversions.ParsePrimitiveStringAsDynamic(valueType, value as String);
         }
 
         /// <summary>

--- a/Ana/Source/Utils/TypeConverters/OffsetConverter.cs
+++ b/Ana/Source/Utils/TypeConverters/OffsetConverter.cs
@@ -37,7 +37,7 @@
                     return "(None)";
                 }
 
-                return String.Join(", ", trueValue.Select(x => Conversions.ParseDecStringAsHexString(typeof(UInt64), x.ToString())));
+                return String.Join(", ", trueValue.Select(x => Conversions.ParsePrimitiveStringAsHexString(typeof(UInt64), x.ToString())));
             }
 
             return base.ConvertTo(context, culture, value, destinationType);

--- a/Ana/Source/Utils/Validation/Conversions.cs
+++ b/Ana/Source/Utils/Validation/Conversions.cs
@@ -16,7 +16,7 @@
         /// <returns>The type that corresponds to the given string</returns>
         public static Type StringToPrimitiveType(String value)
         {
-            return PrimitiveTypes.GetPrimitiveTypes().Where(x => x.Name == value).First();
+            return PrimitiveTypes.GetPrimitiveTypes().Where(x => String.Compare(x.Name, value, true) == 0).First();
         }
 
         /// <summary>
@@ -25,7 +25,7 @@
         /// <param name="valueType">The type the string represents</param>
         /// <param name="value">The string to convert</param>
         /// <returns>The value converted from the given string</returns>
-        public static dynamic ParseDecStringAsValue(Type valueType, String value)
+        public static dynamic ParsePrimitiveStringAsDynamic(Type valueType, String value)
         {
             switch (Type.GetTypeCode(valueType))
             {
@@ -61,14 +61,14 @@
         /// <param name="valueType">The type to convert the parsed hex to</param>
         /// <param name="value">The hex string to parse</param>
         /// <returns>The converted value from the hex</returns>
-        public static dynamic ParseHexStringAsValue(Type valueType, String value)
+        public static dynamic ParseHexStringAsDynamic(Type valueType, String value)
         {
-            return ParseDecStringAsValue(valueType, ParseHexStringAsDecString(valueType, value));
+            return ParsePrimitiveStringAsDynamic(valueType, ParseHexStringAsDecString(valueType, value));
         }
 
-        public static String ParseValueAsDec(Type valueType, dynamic value)
+        public static String ParseDynamicAsPrimitiveString(Type valueType, dynamic value)
         {
-            return ParseDecStringAsValue(valueType, value?.ToString()).ToString();
+            return ParsePrimitiveStringAsDynamic(valueType, value?.ToString()).ToString();
         }
 
         /// <summary>
@@ -77,9 +77,9 @@
         /// <param name="valueType"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        public static String ParseValueAsHex(Type valueType, dynamic value)
+        public static String ParseDynamicAsHex(Type valueType, dynamic value)
         {
-            return ParseDecStringAsHexString(valueType, value?.ToString());
+            return ParsePrimitiveStringAsHexString(valueType, value?.ToString());
         }
 
         /// <summary>
@@ -88,9 +88,9 @@
         /// <param name="valueType">The value type</param>
         /// <param name="value">The hex string to parse</param>
         /// <returns>The converted value from the hex</returns>
-        public static String ParseDecStringAsHexString(Type valueType, String value)
+        public static String ParsePrimitiveStringAsHexString(Type valueType, String value)
         {
-            dynamic realValue = ParseDecStringAsValue(valueType, value);
+            dynamic realValue = ParsePrimitiveStringAsDynamic(valueType, value);
 
             switch (Type.GetTypeCode(valueType))
             {
@@ -144,68 +144,80 @@
             }
         }
 
-        public static String ToAddress(Int32 value)
+        public static String ToHex(Int32 value, Boolean formatAsAddress = true, Boolean includePrefix = false)
         {
-            return ToAddress(unchecked((UInt32)value));
+            return ToHex(unchecked((UInt32)value));
         }
 
-        public static String ToAddress(UInt32 value)
+        public static String ToHex(UInt32 value, Boolean formatAsAddress = true, Boolean includePrefix = false)
         {
             String valueString = value.ToString();
+            String result = 0.ToString();
 
-            if (CheckSyntax.IsUInt32(valueString))
+            if (formatAsAddress)
             {
-                return String.Format("{0:X8}", Convert.ToUInt32(value));
-            }
-            else if (CheckSyntax.IsInt32(valueString))
-            {
-                return String.Format("{0:X8}", unchecked((UInt32)Convert.ToInt32(value)));
+                if (CheckSyntax.IsUInt32(valueString))
+                {
+                    result = String.Format("{0:X8}", Convert.ToUInt32(value));
+                }
+                else if (CheckSyntax.IsInt32(valueString))
+                {
+                    result = String.Format("{0:X8}", unchecked((UInt32)Convert.ToInt32(value)));
+                }
             }
             else
             {
-                return String.Empty;
+                result = value.ToString("X");
             }
+
+            return includePrefix ? "0x" + result : result;
         }
 
-        public static String ToAddress(Int64 value)
+        public static String ToHex(Int64 value, Boolean formatAsAddress = true, Boolean includePrefix = false)
         {
-            return ToAddress(unchecked(value));
+            return ToHex(unchecked((UInt64)value));
         }
 
-        public static String ToAddress(UInt64 value)
+        public static String ToHex(UInt64 value, Boolean formatAsAddress = true, Boolean includePrefix = false)
         {
             String valueString = value.ToString();
+            String result = 0.ToString();
 
-            if (CheckSyntax.IsUInt32(valueString))
+            if (formatAsAddress)
             {
-                return String.Format("{0:X8}", Convert.ToUInt32(value));
-            }
-            else if (CheckSyntax.IsInt32(valueString))
-            {
-                return String.Format("{0:X8}", unchecked((UInt32)Convert.ToInt32(value)));
-            }
-            else if (CheckSyntax.IsUInt64(valueString))
-            {
-                return String.Format("{0:X16}", Convert.ToUInt64(value));
-            }
-            else if (CheckSyntax.IsInt64(valueString))
-            {
-                return String.Format("{0:X16}", unchecked((UInt64)Convert.ToInt64(value)));
+                if (CheckSyntax.IsUInt32(valueString))
+                {
+                    result = String.Format("{0:X8}", Convert.ToUInt32(value));
+                }
+                else if (CheckSyntax.IsInt32(valueString))
+                {
+                    result = String.Format("{0:X8}", unchecked((UInt32)Convert.ToInt32(value)));
+                }
+                else if (CheckSyntax.IsUInt64(valueString))
+                {
+                    result = String.Format("{0:X16}", Convert.ToUInt64(value));
+                }
+                else if (CheckSyntax.IsInt64(valueString))
+                {
+                    result = String.Format("{0:X16}", unchecked((UInt64)Convert.ToInt64(value)));
+                }
             }
             else
             {
-                return String.Empty;
+                result = value.ToString("X");
             }
+
+            return includePrefix ? "0x" + result : result;
         }
 
-        public static String ToAddress(IntPtr value)
+        public static String ToHex(IntPtr value)
         {
-            return ToAddress(value.ToUInt64());
+            return ToHex(value.ToUInt64());
         }
 
-        public static String ToAddress(UIntPtr value)
+        public static String ToHex(UIntPtr value)
         {
-            return ToAddress(value.ToUInt64());
+            return ToHex(value.ToUInt64());
         }
 
         public static UInt64 AddressToValue(String address)

--- a/Ana/View/Controls/HexDecTextBox.cs
+++ b/Ana/View/Controls/HexDecTextBox.cs
@@ -150,11 +150,11 @@
 
             if (this.IsHex)
             {
-                return Conversions.ParseValueAsDec(this.ElementType, Conversions.ParseHexStringAsDecString(this.ElementType, this.Text));
+                return Conversions.ParseDynamicAsPrimitiveString(this.ElementType, Conversions.ParseHexStringAsDecString(this.ElementType, this.Text));
             }
             else
             {
-                return Conversions.ParseValueAsDec(this.ElementType, this.Text);
+                return Conversions.ParseDynamicAsPrimitiveString(this.ElementType, this.Text);
             }
         }
 
@@ -171,11 +171,11 @@
 
             if (this.IsHex)
             {
-                return Conversions.ParseDecStringAsHexString(this.ElementType, Conversions.ParseHexStringAsDecString(this.ElementType, this.Text));
+                return Conversions.ParsePrimitiveStringAsHexString(this.ElementType, Conversions.ParseHexStringAsDecString(this.ElementType, this.Text));
             }
             else
             {
-                return Conversions.ParseDecStringAsHexString(this.ElementType, Conversions.ParseValueAsDec(this.ElementType, this.Text));
+                return Conversions.ParsePrimitiveStringAsHexString(this.ElementType, Conversions.ParseDynamicAsPrimitiveString(this.ElementType, this.Text));
             }
         }
 
@@ -192,11 +192,11 @@
 
             if (this.IsHex)
             {
-                return Conversions.ParseHexStringAsValue(this.ElementType, this.Text);
+                return Conversions.ParseHexStringAsDynamic(this.ElementType, this.Text);
             }
             else
             {
-                return Conversions.ParseDecStringAsValue(this.ElementType, this.Text);
+                return Conversions.ParsePrimitiveStringAsDynamic(this.ElementType, this.Text);
             }
         }
 
@@ -220,11 +220,11 @@
 
             if (this.IsHex)
             {
-                this.Text = Conversions.ParseDecStringAsHexString(this.ElementType, valueString);
+                this.Text = Conversions.ParsePrimitiveStringAsHexString(this.ElementType, valueString);
             }
             else
             {
-                this.Text = Conversions.ParseValueAsDec(this.ElementType, valueString);
+                this.Text = Conversions.ParseDynamicAsPrimitiveString(this.ElementType, valueString);
             }
         }
 
@@ -313,7 +313,7 @@
         {
             if (CheckSyntax.CanParseValue(this.ElementType, this.Text))
             {
-                this.Text = Conversions.ParseDecStringAsHexString(this.ElementType, this.Text);
+                this.Text = Conversions.ParsePrimitiveStringAsHexString(this.ElementType, this.Text);
             }
 
             this.IsHex = true;

--- a/Ana/View/ScriptEditor.xaml
+++ b/Ana/View/ScriptEditor.xaml
@@ -14,7 +14,7 @@
     xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
     x:Name="AnaScriptEditor"
     Title="Script Editor"
-    Width="480"
+    Width="512"
     Height="512"
     d:DesignHeight="256"
     d:DesignWidth="256"

--- a/Ana/View/ScriptEditor.xaml.cs
+++ b/Ana/View/ScriptEditor.xaml.cs
@@ -34,6 +34,7 @@
             this.InitializeComponent();
             this.LoadHightLightRules();
             this.InitializeCompleteionWindow();
+            this.ScriptEditorTextEditor.FontSize = 14;
             //// this.ScriptEditorTextEditor.TextArea.TextEntering += this.ScriptEditorTextEditorTextAreaTextEntering;
             //// this.ScriptEditorTextEditor.TextArea.TextEntered += this.ScriptEditorTextEditorTextAreaTextEntered;
             this.ScriptEditorTextEditor.TextChanged += this.ScriptEditorTextEditorTextChanged;

--- a/AnathenaProxy/AnathenaProxy.cs
+++ b/AnathenaProxy/AnathenaProxy.cs
@@ -17,31 +17,31 @@ namespace AnathenaProxy
     {
         private const Int32 ParentCheckDelayMs = 500;
 
-        public AnathenaProxy(Int32 ParentProcessId, String PipeName, String WaitEventName)
+        public AnathenaProxy(Int32 parentProcessId, String pipeName, String waitEventName)
         {
             // Create an event to have the client wait until we are finished starting the service
-            EventWaitHandle ProcessStartingEvent = new EventWaitHandle(false, EventResetMode.ManualReset, WaitEventName);
+            EventWaitHandle processStartingEvent = new EventWaitHandle(false, EventResetMode.ManualReset, waitEventName);
 
-            InitializeAutoExit(ParentProcessId);
+            InitializeAutoExit(parentProcessId);
 
-            ServiceHost ServiceHost = new ServiceHost(typeof(ProxyService));
-            ServiceHost.Description.Behaviors.Remove(typeof(ServiceDebugBehavior));
-            ServiceHost.Description.Behaviors.Add(new ServiceDebugBehavior { IncludeExceptionDetailInFaults = true });
-            NetNamedPipeBinding Binding = new NetNamedPipeBinding(NetNamedPipeSecurityMode.None);
-            ServiceHost.AddServiceEndpoint(typeof(IProxyService), Binding, PipeName);
-            ServiceHost.Open();
+            ServiceHost serviceHost = new ServiceHost(typeof(ProxyService));
+            serviceHost.Description.Behaviors.Remove(typeof(ServiceDebugBehavior));
+            serviceHost.Description.Behaviors.Add(new ServiceDebugBehavior { IncludeExceptionDetailInFaults = true });
+            NetNamedPipeBinding binding = new NetNamedPipeBinding(NetNamedPipeSecurityMode.None);
+            serviceHost.AddServiceEndpoint(typeof(IProxyService), binding, pipeName);
+            serviceHost.Open();
 
-            ProcessStartingEvent.Set();
+            processStartingEvent.Set();
 
             Console.WriteLine("Anathena proxy library loaded");
             Console.ReadLine();
         }
 
-        public static Boolean IsRunning(Int32 ParentProcessId)
+        public static Boolean IsRunning(Int32 parentProcessId)
         {
             try
             {
-                Process.GetProcessById(ParentProcessId);
+                Process.GetProcessById(parentProcessId);
             }
             catch (ArgumentException)
             {
@@ -51,22 +51,24 @@ namespace AnathenaProxy
             return true;
         }
 
-        private void InitializeAutoExit(Int32 ParentProcessId)
+        private void InitializeAutoExit(Int32 parentProcessId)
         {
             Task.Run(() =>
             {
                 while (true)
                 {
-                    if (!IsRunning(ParentProcessId))
+                    if (!IsRunning(parentProcessId))
+                    {
                         break;
+                    }
 
-                    Thread.Sleep(ParentCheckDelayMs);
+                    Thread.Sleep(AnathenaProxy.ParentCheckDelayMs);
                 }
 
                 Environment.Exit(0);
             });
         }
-
-    } // End class
-
-} // End namespace
+    }
+    //// End class
+}
+//// End namespace

--- a/AnathenaProxy/IProxyService.cs
+++ b/AnathenaProxy/IProxyService.cs
@@ -10,7 +10,7 @@ namespace AnathenaProxy
         #region Fasm
 
         [OperationContract]
-        Byte[] Assemble(Boolean IsProcess32Bit, String Assembly, UInt64 BaseAddress);
+        Byte[] Assemble(Boolean isProcess32Bit, String assembly, UInt64 baseAddress);
 
         #endregion
 
@@ -22,28 +22,28 @@ namespace AnathenaProxy
         [OperationContract]
         IEnumerable<UInt64> GetRoots();
         [OperationContract]
-        Int32 GetRootType(UInt64 RootRef);
+        Int32 GetRootType(UInt64 rootRef);
         [OperationContract]
-        String GetRootName(UInt64 RootRef);
+        String GetRootName(UInt64 rootRef);
 
         [OperationContract]
-        IEnumerable<UInt64> GetObjectChildren(UInt64 ObjectRef);
+        IEnumerable<UInt64> GetObjectChildren(UInt64 objectRef);
         [OperationContract]
-        IEnumerable<UInt64> GetObjectFields(UInt64 ObjectRef);
+        IEnumerable<UInt64> GetObjectFields(UInt64 objectRef);
         [OperationContract]
-        Int32 GetObjectType(UInt64 ObjectRef);
+        Int32 GetObjectType(UInt64 objectRef);
         [OperationContract]
-        String GetObjectName(UInt64 ObjectRef);
+        String GetObjectName(UInt64 objectRef);
 
         [OperationContract]
-        String GetFieldName(UInt64 FieldRef);
+        String GetFieldName(UInt64 fieldRef);
         [OperationContract]
-        Int32 GetFieldType(UInt64 FieldRef);
+        Int32 GetFieldType(UInt64 fieldRef);
         [OperationContract]
-        Int32 GetFieldOffset(UInt64 FieldRef);
+        Int32 GetFieldOffset(UInt64 fieldRef);
 
         #endregion
-
-    } // End class
-
-} // End namespace
+    }
+    //// End class
+}
+//// End namespace

--- a/AnathenaProxy/ProxyService.cs
+++ b/AnathenaProxy/ProxyService.cs
@@ -94,14 +94,16 @@ namespace AnathenaProxy
             return this.Heap == null ? false : true;
         }
 
-        private TypeCode TranslateType(ClrElementType? ElementType)
+        private TypeCode TranslateType(ClrElementType? elementType)
         {
             Type result;
 
-            if (ElementType == null)
+            if (elementType == null)
+            {
                 return TypeCode.Empty;
+            }
 
-            switch (ElementType)
+            switch (elementType)
             {
                 case ClrElementType.Boolean:
                     result = typeof(Boolean);


### PR DESCRIPTION
- Fixes to 64 bit code cave injection. The allocated page was out of range of a far jump, causing the assembler to fail.
- Simplifications to Memory API for scripts. The call/return are automatic for injected code now.
- Script template fixes to reflect API changes.
- Style fixes
- Some conversion name updates for clarity
