### PR TITLE
Fixes to VirtualAllocEx, Adjustments to Memory API for Scripts

### DIFF
--- a/Ana/Ana.csproj
+++ b/Ana/Ana.csproj
@@ -442,6 +442,7 @@
     <Compile Include="Source\Utils\Extensions\DependencyObjectExtensions.cs" />
     <Compile Include="Source\Utils\Extensions\StringExtensions.cs" />
     <Compile Include="Source\Utils\Hashing.cs" />
+    <Compile Include="Source\Utils\StaticRandom.cs" />
     <Compile Include="Source\Utils\TypeEditors\HotkeyEditor\HotkeyEditorViewModel.cs" />
     <Compile Include="Source\Utils\TypeEditors\HotkeyEditor\HotkeyEditorModel.cs" />
     <Compile Include="Source\Utils\TypeEditors\OffsetEditor\OffsetEditorViewModel.cs" />

--- a/Ana/Source/Engine/AddressResolver/AddressResolver.cs
+++ b/Ana/Source/Engine/AddressResolver/AddressResolver.cs
@@ -107,10 +107,8 @@
         /// <returns>The base address as defined by the keyword.</returns>
         public IntPtr ResolveGlobalKeyword(String identifier)
         {
-            IntPtr result = IntPtr.Zero;
-
             ScriptEngine.ScriptEngine scriptEngine = new ScriptEngine.ScriptEngine();
-            return scriptEngine.MemoryCore.GetGlobalKeywordValue(identifier).ToIntPtr();
+            return scriptEngine.MemoryCore.GetGlobalKeyword(identifier)?.ToIntPtr();
         }
 
         /// <summary>

--- a/Ana/Source/Engine/Input/Keyboard/KeyboardCapture.cs
+++ b/Ana/Source/Engine/Input/Keyboard/KeyboardCapture.cs
@@ -14,7 +14,6 @@
         /// </summary>
         public KeyboardCapture()
         {
-            SharpDX.RawInput.Device.RegisterDevice(SharpDX.Multimedia.UsagePage.Generic, SharpDX.Multimedia.UsageId.GenericKeyboard, SharpDX.RawInput.DeviceFlags.None);
             this.Subjects = new List<IKeyboardObserver>();
             this.DirectInput = new DirectInput();
             this.Keyboard = new Keyboard(this.DirectInput);
@@ -81,7 +80,7 @@
         {
             try
             {
-                this.CurrentKeyboardState = Keyboard.GetCurrentState();
+                this.CurrentKeyboardState = this.Keyboard.GetCurrentState();
 
                 if (this.PreviousKeyboardState == null)
                 {

--- a/Ana/Source/Engine/OperatingSystems/Windows/Memory.cs
+++ b/Ana/Source/Engine/OperatingSystems/Windows/Memory.cs
@@ -6,6 +6,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Runtime.InteropServices;
+    using Utils;
     using Utils.Extensions;
     using static Native.Enumerations;
     using static Native.Structures;
@@ -19,11 +20,6 @@
         /// The number of retry attempts for 64-bit process allocation. This is a work around due to non-deterministic allocation failures.
         /// </summary>
         private const Int32 AllocateRetryCount = 64;
-
-        /// <summary>
-        /// Random class instance.
-        /// </summary>
-        private static readonly Random Random = new Random();
 
         /// <summary>
         /// Reads an array of bytes in the memory form the target process.
@@ -97,10 +93,11 @@
 
                 Int32 retryCount = 0;
                 IntPtr result = IntPtr.Zero;
-                IEnumerable<MemoryBasicInformation64> freeMemory = UnallocatedMemory(processHandle, allocAddress.Subtract(Int32.MaxValue >> 2), allocAddress.Add(Int32.MaxValue >> 2));
+                IEnumerable<MemoryBasicInformation64> freeMemory = Memory.UnallocatedMemory(processHandle, allocAddress.Subtract(Int32.MaxValue >> 2), allocAddress.Add(Int32.MaxValue >> 2));
+
                 do
                 {
-                    result = freeMemory.ElementAt(Memory.Random.Next(0, freeMemory.Count())).BaseAddress;
+                    result = freeMemory.ElementAt(StaticRandom.Next(0, freeMemory.Count())).BaseAddress;
                     result = NativeMethods.VirtualAllocEx(processHandle, result, size, allocationFlags, protectionFlags);
 
                     if (result != IntPtr.Zero || retryCount >= Memory.AllocateRetryCount)

--- a/Ana/Source/Engine/OperatingSystems/Windows/Memory.cs
+++ b/Ana/Source/Engine/OperatingSystems/Windows/Memory.cs
@@ -17,9 +17,14 @@
     internal static class Memory
     {
         /// <summary>
-        /// The number of retry attempts for 64-bit process allocation. This is a work around due to non-deterministic allocation failures.
+        /// The number of retry attempts for memory allocation. This is used to prevent cases of bad luck for 64-bit memory allocation when a specific address is requested.
         /// </summary>
-        private const Int32 AllocateRetryCount = 64;
+        private const Int32 AllocateRetryCount = 4;
+
+        /// <summary>
+        /// A windows constraint on the address alignment of an allocated virtual memory page.
+        /// </summary>
+        private const Int32 AllocAlignment = 0x10000;
 
         /// <summary>
         /// Reads an array of bytes in the memory form the target process.
@@ -85,19 +90,36 @@
             if (allocAddress != IntPtr.Zero)
             {
                 /* A specific address has been given. We will modify it to support the following constraints:
-                 * - Aligned by 0x10000 / 65536
-                 * - Pointing to an unallocated region of memory
-                 * - Within +/- 2GB (using 256MB for safety) of address space of the originally specified address, such as to always be in range of a far jump instruction
-                 * Note: This does not seem to guarentee a valid result, so a retry count has been put in place.
+                 *  - Aligned by 0x10000 / 65536
+                 *  - Pointing to an unallocated region of memory
+                 *  - Within +/- 2GB (using 1GB for safety) of address space of the originally specified address, such as to always be in range of a far jump instruction
+                 * Note: A retry count has been put in place because VirtualAllocEx with an allocAddress specified may be invalid by the time we request the allocation.
                  */
 
-                Int32 retryCount = 0;
                 IntPtr result = IntPtr.Zero;
-                IEnumerable<MemoryBasicInformation64> freeMemory = Memory.UnallocatedMemory(processHandle, allocAddress.Subtract(Int32.MaxValue >> 2), allocAddress.Add(Int32.MaxValue >> 2));
+                Int32 retryCount = 0;
+
+                // Request all chunks of unallocated memory. These will be very large in a 64-bit process.
+                IEnumerable<MemoryBasicInformation64> freeMemory = Memory.QueryUnallocatedMemory(
+                    processHandle,
+                    allocAddress.Subtract(Int32.MaxValue >> 1, wrapAround: false),
+                    allocAddress.Add(Int32.MaxValue >> 1, wrapAround: false));
+
+                // Convert to normalized regions
+                IEnumerable<NormalizedRegion> regions = freeMemory.Select(x => new NormalizedRegion(x.BaseAddress, unchecked((Int32)x.RegionSize)));
+
+                // Chunk the large regions into smaller regions based on the allocation size (minimum size is the alloc alignment to prevent creating too many chunks)
+                List<NormalizedRegion> subRegions = new List<NormalizedRegion>();
+                foreach (NormalizedRegion region in regions)
+                {
+                    region.BaseAddress = region.BaseAddress.Subtract(region.BaseAddress.Mod(Memory.AllocAlignment), wrapAround: false);
+                    subRegions.AddRange(region.ChunkNormalizedRegion(Math.Max(size, Memory.AllocAlignment)).Select(x => x).Where(x => x.RegionSize >= size));
+                }
 
                 do
                 {
-                    result = freeMemory.ElementAt(StaticRandom.Next(0, freeMemory.Count())).BaseAddress;
+                    // Sample a random chunk and attempt to allocate the memory
+                    result = subRegions.ElementAt(StaticRandom.Next(0, subRegions.Count())).BaseAddress;
                     result = NativeMethods.VirtualAllocEx(processHandle, result, size, allocationFlags, protectionFlags);
 
                     if (result != IntPtr.Zero || retryCount >= Memory.AllocateRetryCount)
@@ -178,7 +200,7 @@
         /// <returns>
         /// A collection of <see cref="MemoryBasicInformation64"/> structures containing info about all virtual pages in the target process.
         /// </returns>
-        public static IEnumerable<MemoryBasicInformation64> UnallocatedMemory(
+        public static IEnumerable<MemoryBasicInformation64> QueryUnallocatedMemory(
             IntPtr processHandle,
             IntPtr startAddress,
             IntPtr endAddress)

--- a/Ana/Source/ScriptEngine/Memory/IMemoryCore.cs
+++ b/Ana/Source/ScriptEngine/Memory/IMemoryCore.cs
@@ -53,7 +53,7 @@
         /// <param name="size">The size of the allocation.</param>
         /// <param name="allocAddress">The rough address of where the allocation should take place.</param>
         /// <returns>The address of the allocated memory.</returns>
-        UInt64 AllocateMemory(Int32 size, IntPtr allocAddress);
+        UInt64 AllocateMemory(Int32 size, UInt64 allocAddress);
 
         /// <summary>
         /// Deallocates memory previously allocated at a specified address.
@@ -105,29 +105,29 @@
         /// Binds a keyword to a given value for use in the script.
         /// </summary>
         /// <param name="keyword">The local keyword to bind.</param>
-        /// <param name="address">The address to which the keyword is bound.</param>
-        void SetKeyword(String keyword, UInt64 address);
+        /// <param name="value">The address to which the keyword is bound.</param>
+        void SetKeyword(String keyword, dynamic value);
 
         /// <summary>
         /// Binds a keyword to a given value for use in all scripts.
         /// </summary>
         /// <param name="globalKeyword">The global keyword to bind.</param>
-        /// <param name="address">The address to which the keyword is bound.</param>
-        void SetGlobalKeyword(String globalKeyword, UInt64 address);
+        /// <param name="value">The value to which the keyword is bound.</param>
+        void SetGlobalKeyword(String globalKeyword, dynamic value);
 
         /// <summary>
         /// Gets the value of a keyword.
         /// </summary>
         /// <param name="keyword">The keyword.</param>
         /// <returns>The value of the keyword. If not found, returns 0.</returns>
-        UInt64 GetKeywordValue(String keyword);
+        dynamic GetKeyword(String keyword);
 
         /// <summary>
         /// Gets the value of a global keyword.
         /// </summary>
         /// <param name="globalKeyword">The global keyword.</param>
         /// <returns>The value of the global keyword. If not found, returns 0.</returns>
-        UInt64 GetGlobalKeywordValue(String globalKeyword);
+        dynamic GetGlobalKeyword(String globalKeyword);
 
         /// <summary>
         /// Clears the specified keyword created by the parent script.

--- a/Ana/Source/Utils/Extensions/IntPtrExtensions.cs
+++ b/Ana/Source/Utils/Extensions/IntPtrExtensions.cs
@@ -1,13 +1,32 @@
 ﻿namespace Ana.Source.Utils.Extensions
 {
     using System;
+    using System.Linq.Expressions;
 
     /// <summary>
     /// Extension methods for converting and operating on <see cref="IntPtr"/> types.
     /// </summary>
     public static class IntPtrExtensions
     {
-        #region Integer conversions
+        /// <summary>
+        /// Converts the given pointer to a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="intPtr">The pointer to convert.</param>
+        /// <returns>The pointer converted to a <see cref="IntPtr"/>.</returns>
+        public static unsafe IntPtr ToIntPtr(this UIntPtr intPtr)
+        {
+            return unchecked((IntPtr)intPtr.ToPointer());
+        }
+
+        /// <summary>
+        /// Converts the given pointer to a <see cref="UIntPtr"/>.
+        /// </summary>
+        /// <param name="intPtr">The pointer to convert.</param>
+        /// <returns>The pointer converted to a <see cref="UIntPtr"/>.</returns>
+        public static unsafe UIntPtr ToUIntPtr(this IntPtr intPtr)
+        {
+            return unchecked((UIntPtr)intPtr.ToPointer());
+        }
 
         /// <summary>
         /// Converts an <see cref="IntPtr"/> to an unsigned <see cref="UInt32"/>.
@@ -49,23 +68,16 @@
             return unchecked((UInt64)intPtr);
         }
 
-        #endregion
-
-        #region IntPtr operations
-
         /// <summary>
         /// Performs the addition operation with the given values.
         /// </summary>
         /// <param name="left">The left side value.</param>
         /// <param name="right">The right side value.</param>
+        /// <param name="wrapAround">Whether or not values will wrap if the operation overflows. Otherwise, cap out at IntPtr.MaxValue or IntPtr.MinValue.</param>
         /// <returns>The result of the operation.</returns>
-        public static IntPtr Add(this IntPtr left, IntPtr right)
+        public static IntPtr Add(this IntPtr left, dynamic right, Boolean wrapAround = true)
         {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() + (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToIntPtr();
-            }
+            return IntPtrExtensions.DoOperation(left, right, ExpressionType.Add, wrapAround);
         }
 
         /// <summary>
@@ -73,119 +85,11 @@
         /// </summary>
         /// <param name="left">The left side value.</param>
         /// <param name="right">The right side value.</param>
+        /// <param name="wrapAround">Whether or not values will wrap if the operation overflows. Otherwise, cap out at IntPtr.MaxValue or IntPtr.MinValue.</param>
         /// <returns>The result of the operation.</returns>
-        public static IntPtr Add(this IntPtr left, Byte right)
+        public static UIntPtr Add(this UIntPtr left, dynamic right, Boolean wrapAround = true)
         {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() + (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Add(this IntPtr left, SByte right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() + (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Add(this IntPtr left, Int16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() + (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Add(this IntPtr left, UInt16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() + (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Add(this IntPtr left, Int32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() + (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Add(this IntPtr left, UInt32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() + (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Add(this IntPtr left, Int64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() + (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Add(this IntPtr left, UInt64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() + (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToIntPtr();
-            }
+            return IntPtrExtensions.DoOperation(left.ToIntPtr(), right, ExpressionType.Add, wrapAround).ToUIntPtr();
         }
 
         /// <summary>
@@ -193,14 +97,11 @@
         /// </summary>
         /// <param name="left">The left side value.</param>
         /// <param name="right">The right side value.</param>
+        /// <param name="wrapAround">Whether or not values will wrap if the operation overflows. Otherwise, cap out at IntPtr.MaxValue or IntPtr.MinValue.</param>
         /// <returns>The result of the operation.</returns>
-        public static IntPtr Subtract(this IntPtr left, IntPtr right)
+        public static IntPtr Subtract(this IntPtr left, dynamic right, Boolean wrapAround = true)
         {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() - (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToIntPtr();
-            }
+            return IntPtrExtensions.DoOperation(left, right, ExpressionType.Subtract, wrapAround);
         }
 
         /// <summary>
@@ -208,119 +109,11 @@
         /// </summary>
         /// <param name="left">The left side value.</param>
         /// <param name="right">The right side value.</param>
+        /// <param name="wrapAround">Whether or not values will wrap if the operation overflows. Otherwise, cap out at IntPtr.MaxValue or IntPtr.MinValue.</param>
         /// <returns>The result of the operation.</returns>
-        public static IntPtr Subtract(this IntPtr left, Byte right)
+        public static UIntPtr Subtract(this UIntPtr left, dynamic right, Boolean wrapAround = true)
         {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() - (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Subtract(this IntPtr left, SByte right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() - (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Subtract(this IntPtr left, Int16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() - (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Subtract(this IntPtr left, UInt16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() - (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Subtract(this IntPtr left, Int32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() - (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Subtract(this IntPtr left, UInt32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() - (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Subtract(this IntPtr left, Int64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() - (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Subtract(this IntPtr left, UInt64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() - (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToIntPtr();
-            }
+            return IntPtrExtensions.DoOperation(left.ToIntPtr(), right, ExpressionType.Subtract, wrapAround).ToUIntPtr();
         }
 
         /// <summary>
@@ -328,14 +121,11 @@
         /// </summary>
         /// <param name="left">The left side value.</param>
         /// <param name="right">The right side value.</param>
+        /// <param name="wrapAround">Whether or not values will wrap if the operation overflows. Otherwise, cap out at IntPtr.MaxValue or IntPtr.MinValue.</param>
         /// <returns>The result of the operation.</returns>
-        public static IntPtr Multiply(this IntPtr left, IntPtr right)
+        public static IntPtr Multiply(this IntPtr left, dynamic right, Boolean wrapAround = true)
         {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() * (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToIntPtr();
-            }
+            return IntPtrExtensions.DoOperation(left, right, ExpressionType.Multiply, wrapAround);
         }
 
         /// <summary>
@@ -343,119 +133,11 @@
         /// </summary>
         /// <param name="left">The left side value.</param>
         /// <param name="right">The right side value.</param>
+        /// <param name="wrapAround">Whether or not values will wrap if the operation overflows. Otherwise, cap out at IntPtr.MaxValue or IntPtr.MinValue.</param>
         /// <returns>The result of the operation.</returns>
-        public static IntPtr Multiply(this IntPtr left, Byte right)
+        public static UIntPtr Multiply(this UIntPtr left, dynamic right, Boolean wrapAround = true)
         {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() * (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Multiply(this IntPtr left, SByte right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() * (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Multiply(this IntPtr left, Int16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() * (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Multiply(this IntPtr left, UInt16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() * (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Multiply(this IntPtr left, Int32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() * (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Multiply(this IntPtr left, UInt32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() * (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Multiply(this IntPtr left, Int64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() * (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Multiply(this IntPtr left, UInt64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() * (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToIntPtr();
-            }
+            return IntPtrExtensions.DoOperation(left.ToIntPtr(), right, ExpressionType.Multiply, wrapAround).ToUIntPtr();
         }
 
         /// <summary>
@@ -464,13 +146,9 @@
         /// <param name="left">The left side value.</param>
         /// <param name="right">The right side value.</param>
         /// <returns>The result of the operation.</returns>
-        public static IntPtr Divide(this IntPtr left, IntPtr right)
+        public static IntPtr Divide(this IntPtr left, dynamic right)
         {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() / (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToIntPtr();
-            }
+            return IntPtrExtensions.DoOperation(left, right, ExpressionType.Multiply);
         }
 
         /// <summary>
@@ -479,118 +157,9 @@
         /// <param name="left">The left side value.</param>
         /// <param name="right">The right side value.</param>
         /// <returns>The result of the operation.</returns>
-        public static IntPtr Divide(this IntPtr left, Byte right)
+        public static UIntPtr Divide(this UIntPtr left, dynamic right)
         {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() / (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Divide(this IntPtr left, SByte right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() / (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Divide(this IntPtr left, Int16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() / (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Divide(this IntPtr left, UInt16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() / (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Divide(this IntPtr left, Int32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() / (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Divide(this IntPtr left, UInt32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() / (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Divide(this IntPtr left, Int64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() / (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Divide(this IntPtr left, UInt64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() / (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToIntPtr();
-            }
+            return IntPtrExtensions.DoOperation(left.ToIntPtr(), right, ExpressionType.Multiply).ToUIntPtr();
         }
 
         /// <summary>
@@ -599,13 +168,9 @@
         /// <param name="left">The left side value.</param>
         /// <param name="right">The right side value.</param>
         /// <returns>The result of the operation.</returns>
-        public static IntPtr Mod(this IntPtr left, IntPtr right)
+        public static IntPtr Mod(this IntPtr left, dynamic right)
         {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() % (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToIntPtr();
-            }
+            return IntPtrExtensions.DoOperation(left, right, ExpressionType.Modulo);
         }
 
         /// <summary>
@@ -614,799 +179,142 @@
         /// <param name="left">The left side value.</param>
         /// <param name="right">The right side value.</param>
         /// <returns>The result of the operation.</returns>
-        public static IntPtr Mod(this IntPtr left, Byte right)
+        public static UIntPtr Mod(this UIntPtr left, dynamic right)
         {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() % (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToIntPtr();
-            }
+            return IntPtrExtensions.DoOperation(left.ToIntPtr(), right, ExpressionType.Modulo).ToUIntPtr();
         }
 
         /// <summary>
-        /// Performs the modulo operation with the given values.
+        /// Performs the given mathematical operation on the given left and right values.
         /// </summary>
         /// <param name="left">The left side value.</param>
         /// <param name="right">The right side value.</param>
+        /// <param name="expression">The mathematical operation to perform.</param>
+        /// <param name="wrapAround">Whether or not values will wrap if the operation overflows. Otherwise, cap out at IntPtr.MaxValue or IntPtr.MinValue.</param>
         /// <returns>The result of the operation.</returns>
-        public static IntPtr Mod(this IntPtr left, SByte right)
+        private static IntPtr DoOperation(IntPtr left, dynamic right, ExpressionType expression, Boolean wrapAround = true)
         {
-            switch (IntPtr.Size)
+            dynamic leftSide;
+            dynamic rightSide;
+
+            if (wrapAround)
             {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() % (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToIntPtr();
+                switch (IntPtr.Size)
+                {
+                    case sizeof(Int32):
+                        leftSide = left.ToUInt32();
+                        rightSide = (UInt32)right;
+                        break;
+                    default:
+                        leftSide = left.ToUInt64();
+                        rightSide = (UInt64)right;
+                        break;
+                }
+            }
+            else
+            {
+                switch (IntPtr.Size)
+                {
+                    case sizeof(Int32):
+                        leftSide = left.ToUInt32();
+                        rightSide = unchecked((UInt32)right);
+                        break;
+                    default:
+                        leftSide = left.ToUInt64();
+                        rightSide = unchecked((UInt64)right);
+                        break;
+                }
+            }
+
+            try
+            {
+                switch (expression)
+                {
+                    case ExpressionType.Add:
+                        switch (IntPtr.Size)
+                        {
+                            case sizeof(Int32):
+                                return wrapAround ? unchecked((Int32)(leftSide + rightSide)).ToIntPtr() : checked((Int32)(leftSide + rightSide)).ToIntPtr();
+                            default:
+                                return wrapAround ? unchecked((Int64)(leftSide + rightSide)).ToIntPtr() : checked((Int64)(leftSide + rightSide)).ToIntPtr();
+                        }
+
+                    case ExpressionType.Subtract:
+                        switch (IntPtr.Size)
+                        {
+                            case sizeof(Int32):
+                                return wrapAround ? unchecked((Int32)(leftSide - rightSide)).ToIntPtr() : checked((Int32)(leftSide - rightSide)).ToIntPtr();
+                            default:
+                                return wrapAround ? unchecked((Int64)(leftSide - rightSide)).ToIntPtr() : checked((Int64)(leftSide - rightSide)).ToIntPtr();
+                        }
+
+                    case ExpressionType.Multiply:
+                        switch (IntPtr.Size)
+                        {
+                            case sizeof(Int32):
+                                return wrapAround ? unchecked((Int32)(leftSide * rightSide)).ToIntPtr() : checked((Int32)(leftSide * rightSide)).ToIntPtr();
+                            default:
+                                return wrapAround ? unchecked((Int64)(leftSide * rightSide)).ToIntPtr() : checked((Int64)(leftSide * rightSide)).ToIntPtr();
+                        }
+
+                    case ExpressionType.Divide:
+                        switch (IntPtr.Size)
+                        {
+                            case sizeof(Int32):
+                                return unchecked((Int32)(leftSide / rightSide)).ToIntPtr();
+                            default:
+                                return unchecked((Int64)(leftSide / rightSide)).ToIntPtr();
+                        }
+
+                    case ExpressionType.Modulo:
+                        switch (IntPtr.Size)
+                        {
+                            case sizeof(Int32):
+                                return unchecked((Int32)(leftSide % rightSide)).ToIntPtr();
+                            default:
+                                return unchecked((Int64)(leftSide % rightSide)).ToIntPtr();
+                        }
+
+                    default:
+                        throw new Exception("Unknown operation");
+                }
+            }
+            catch (OverflowException ex)
+            {
+                switch (expression)
+                {
+                    case ExpressionType.Add:
+                        switch (IntPtr.Size)
+                        {
+                            case sizeof(Int32):
+                                return rightSide >= 0 ? Int32.MaxValue.ToIntPtr() : Int32.MinValue.ToIntPtr();
+                            default:
+                                return rightSide >= 0 ? Int64.MaxValue.ToIntPtr() : Int64.MinValue.ToIntPtr();
+                        }
+
+                    case ExpressionType.Multiply:
+                        switch (IntPtr.Size)
+                        {
+                            case sizeof(Int32):
+                                return ((rightSide >= 0 && leftSide >= 0) || (rightSide <= 0 && leftSide <= 0)) ? Int32.MaxValue.ToIntPtr() : Int32.MinValue.ToIntPtr();
+                            default:
+                                return ((rightSide >= 0 && leftSide >= 0) || (rightSide <= 0 && leftSide <= 0)) ? Int64.MaxValue.ToIntPtr() : Int64.MinValue.ToIntPtr();
+                        }
+
+                    case ExpressionType.Subtract:
+                        switch (IntPtr.Size)
+                        {
+                            case sizeof(Int32):
+                                return rightSide >= 0 ? Int32.MinValue.ToIntPtr() : Int32.MaxValue.ToIntPtr();
+                            default:
+                                return rightSide >= 0 ? Int64.MinValue.ToIntPtr() : Int64.MaxValue.ToIntPtr();
+                        }
+
+                    default:
+                        throw ex;
+                }
             }
         }
-
-        /// <summary>
-        /// Performs the modulo operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Mod(this IntPtr left, Int16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() % (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the modulo operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Mod(this IntPtr left, UInt16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() % (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the modulo operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Mod(this IntPtr left, Int32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() % (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the modulo operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Mod(this IntPtr left, UInt32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() % (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the modulo operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Mod(this IntPtr left, Int64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() % (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the modulo operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static IntPtr Mod(this IntPtr left, UInt64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked((Int32)(left.ToUInt32() % (UInt32)right)).ToIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToIntPtr();
-            }
-        }
-
-        #endregion
-
-        #region UIntPtr operations
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Add(this UIntPtr left, UIntPtr right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() + (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Add(this UIntPtr left, Byte right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() + (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Add(this UIntPtr left, SByte right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() + (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Add(this UIntPtr left, Int16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() + (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Add(this UIntPtr left, UInt16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() + (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Add(this UIntPtr left, Int32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() + (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Add(this UIntPtr left, UInt32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() + (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Add(this UIntPtr left, Int64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() + (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the addition operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Add(this UIntPtr left, UInt64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() + (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() + (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Subtract(this UIntPtr left, UIntPtr right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() - (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Subtract(this UIntPtr left, Byte right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() - (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Subtract(this UIntPtr left, SByte right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() - (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Subtract(this UIntPtr left, Int16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() - (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Subtract(this UIntPtr left, UInt16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() - (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Subtract(this UIntPtr left, Int32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() - (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Subtract(this UIntPtr left, UInt32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() - (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Subtract(this UIntPtr left, Int64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() - (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the subtraction operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Subtract(this UIntPtr left, UInt64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() - (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() - (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Multiply(this UIntPtr left, UIntPtr right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() * (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Multiply(this UIntPtr left, Byte right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() * (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Multiply(this UIntPtr left, SByte right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() * (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Multiply(this UIntPtr left, Int16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() * (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Multiply(this UIntPtr left, UInt16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() * (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Multiply(this UIntPtr left, Int32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() * (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Multiply(this UIntPtr left, UInt32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() * (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Multiply(this UIntPtr left, Int64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() * (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Multiply(this UIntPtr left, UInt64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() * (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() * (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Divide(this UIntPtr left, UIntPtr right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() / (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Divide(this UIntPtr left, Byte right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() / (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Divide(this UIntPtr left, SByte right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() / (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Divide(this UIntPtr left, Int16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() / (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Divide(this UIntPtr left, UInt16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() / (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Divide(this UIntPtr left, Int32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() / (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Divide(this UIntPtr left, UInt32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() / (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Divide(this UIntPtr left, Int64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() / (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the division operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Divide(this UIntPtr left, UInt64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() / (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() / (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the modulo operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Mod(this UIntPtr left, UIntPtr right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() % (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the modulo operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Mod(this UIntPtr left, Byte right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() % (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the modulo operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Mod(this UIntPtr left, SByte right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() % (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the modulo operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Mod(this UIntPtr left, Int16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() % (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the modulo operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Mod(this UIntPtr left, UInt16 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() % (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the modulo operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Mod(this UIntPtr left, Int32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() % (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the modulo operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Mod(this UIntPtr left, UInt32 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() % (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the modulo operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Mod(this UIntPtr left, Int64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() % (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToUIntPtr();
-            }
-        }
-
-        /// <summary>
-        /// Performs the modulo operation with the given values.
-        /// </summary>
-        /// <param name="left">The left side value.</param>
-        /// <param name="right">The right side value.</param>
-        /// <returns>The result of the operation.</returns>
-        public static UIntPtr Mod(this UIntPtr left, UInt64 right)
-        {
-            switch (IntPtr.Size)
-            {
-                case sizeof(Int32): return unchecked(left.ToUInt32() % (UInt32)right).ToUIntPtr();
-                default: return unchecked(left.ToUInt64() % (UInt64)right).ToUIntPtr();
-            }
-        }
-        #endregion
     }
     //// End class
 }

--- a/Ana/Source/Utils/StaticRandom.cs
+++ b/Ana/Source/Utils/StaticRandom.cs
@@ -1,0 +1,43 @@
+﻿namespace Ana.Source.Utils
+{
+    using System;
+    using System.Threading;
+
+    /// <summary>
+    /// A thread safe static random class.
+    /// </summary>
+    internal static class StaticRandom
+    {
+        /// <summary>
+        /// The thread safe random class instance.
+        /// </summary>
+        private static readonly ThreadLocal<Random> Random = new ThreadLocal<Random>(() => new Random(Interlocked.Increment(ref seed)));
+
+        /// <summary>
+        /// The random seed.
+        /// </summary>
+        private static Int32 seed = Environment.TickCount;
+
+        /// <summary>
+        /// Returns a thread safe random integer.
+        /// </summary>
+        /// <returns>A random integer.</returns>
+        public static Int32 Next()
+        {
+            return Random.Value.Next();
+        }
+
+        /// <summary>
+        /// Returns a thread safe random integer.
+        /// </summary>
+        /// <param name="min">The inclusive lower bound of the number returned.</param>
+        /// <param name="max">The exclusive upper bound of the number returned.</param>
+        /// <returns>A random integer.</returns>
+        public static Int32 Next(Int32 min, Int32 max)
+        {
+            return Random.Value.Next(min, max);
+        }
+    }
+    //// End class
+}
+//// End namespace

--- a/Ana/View/ProjectExplorer.xaml.cs
+++ b/Ana/View/ProjectExplorer.xaml.cs
@@ -398,7 +398,12 @@
         private IEnumerable<ProjectItem> GetSelectedProjectItems()
         {
             List<ProjectItem> nodes = new List<ProjectItem>();
-            this.projectExplorerTreeView.SelectedNodes.ForEach(x => nodes.Add(this.GetProjectItemFromNode(x)));
+
+            foreach (TreeNodeAdv node in this.projectExplorerTreeView.SelectedNodes.ToArray())
+            {
+                nodes.Add(this.GetProjectItemFromNode(node));
+            }
+
             return nodes;
         }
 
@@ -408,8 +413,12 @@
         /// <returns>A collection of the cloned project items.</returns>
         private IEnumerable<ProjectItem> CloneSelectedProjectItems()
         {
-            List<ProjectItem> nodes = new List<ProjectItem>();
-            this.projectExplorerTreeView.SelectedNodes.ForEach(x => nodes.Add(this.GetProjectItemFromNode(x).Clone()));
+            IList<ProjectItem> nodes = new List<ProjectItem>();
+            foreach (ProjectItem node in this.GetSelectedProjectItems())
+            {
+                nodes.Add(node);
+            }
+
             return nodes;
         }
 
@@ -428,14 +437,9 @@
         /// </summary>
         private void ActivateSelectedItems()
         {
-            if (this.projectExplorerTreeView.SelectedNodes == null || this.projectExplorerTreeView.SelectedNodes.Count <= 0)
-            {
-                return;
-            }
-
             IEnumerable<ProjectItem> selectedProjectItems = this.GetSelectedProjectItems();
 
-            if (selectedProjectItems == null || selectedProjectItems.Count() <= 0)
+            if (selectedProjectItems.IsNullOrEmpty())
             {
                 return;
             }
@@ -443,9 +447,8 @@
             // Behavior here is undefined, we could check only the selected items, or enforce the recursive rules of folders
             selectedProjectItems.ForEach(x => this.CheckItem(x, !x.IsActivated));
 
-            foreach (TreeNodeAdv projectNode in this.projectExplorerTreeView.SelectedNodes)
+            foreach (ProjectItem projectItem in this.GetSelectedProjectItems())
             {
-                ProjectItem projectItem = this.GetProjectItemFromNode(projectNode);
                 ProjectNode result;
 
                 if (this.nodeCache.TryGetValue(projectItem, out result))
@@ -462,14 +465,9 @@
         /// </summary>
         private void CompileSelectedItems()
         {
-            if (this.projectExplorerTreeView.SelectedNodes == null || this.projectExplorerTreeView.SelectedNodes.Count <= 0)
-            {
-                return;
-            }
-
             IEnumerable<ProjectItem> selectedProjectItems = this.GetSelectedProjectItems();
 
-            if (selectedProjectItems == null || selectedProjectItems.Count() <= 0)
+            if (selectedProjectItems.IsNullOrEmpty())
             {
                 return;
             }
@@ -493,7 +491,7 @@
         /// </summary>
         private void DeleteSelectedItems()
         {
-            if (this.projectExplorerTreeView.SelectedNodes == null || this.projectExplorerTreeView.SelectedNodes.Count <= 0)
+            if (this.GetSelectedProjectItems().IsNullOrEmpty())
             {
                 return;
             }
@@ -612,9 +610,9 @@
             // Update the view model with the selected nodes
             List<ProjectItem> projectItems = new List<ProjectItem>();
 
-            foreach (TreeNodeAdv node in this.projectExplorerTreeView.SelectedNodes.ToArray())
+            foreach (ProjectItem node in this.GetSelectedProjectItems())
             {
-                projectItems.Add(this.GetProjectItemFromNode(node));
+                projectItems.Add(node);
             }
 
             ProjectExplorerViewModel.GetInstance().SelectedProjectItems = projectItems;
@@ -816,7 +814,7 @@
         /// <param name="e">Event args.</param>
         private void ContextMenuStripOpening(Object sender, CancelEventArgs e)
         {
-            if (this.projectExplorerTreeView.SelectedNodes == null || this.projectExplorerTreeView.SelectedNodes.Count <= 0)
+            if (this.GetSelectedProjectItems().IsNullOrEmpty())
             {
                 this.deleteSelectionMenuItem.Enabled = false;
                 this.toggleSelectionMenuItem.Enabled = false;
@@ -831,7 +829,7 @@
                 this.copySelectionMenuItem.Enabled = true;
                 this.cutSelectionMenuItem.Enabled = true;
 
-                if (this.projectExplorerTreeView.SelectedNodes.All(x => this.GetProjectItemFromNode(x)?.GetType() == typeof(ScriptItem)))
+                if (this.GetSelectedProjectItems().All(x => x?.GetType() == typeof(ScriptItem)))
                 {
                     this.compileSelectionMenuItem.Visible = true;
                 }

--- a/CsScriptLibrary/csscriptlibrary.xml
+++ b/CsScriptLibrary/csscriptlibrary.xml
@@ -4378,6 +4378,11 @@
             If set to 'true' "static...Main" in the imported script is not renamed.
             </summary>
         </member>
+        <member name="M:csscript.CSharpParser.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:csscript.CSharpParser"/> class.
+            </summary>
+        </member>
         <member name="M:csscript.CSharpParser.#ctor(System.String)">
             <summary>
             Creates an instance of CSharpParser.


### PR DESCRIPTION
VirtualAllocEx works pretty reliably on 64 bit now when dealing with injected code caves.

Updated memory API to allow keywords to store any data type, instead of just UInt64