### PR TITLE
Fixed Min/Max Bounds on Label Thresholder.

### DIFF
--- a/Ana/Ana.csproj
+++ b/Ana/Ana.csproj
@@ -32,11 +32,11 @@
     <ErrorReportUrl>https://www.anathena.com/</ErrorReportUrl>
     <ProductName>Anathena</ProductName>
     <PublisherName>Anathena</PublisherName>
-    <MinimumRequiredVersion>3.4.5.0</MinimumRequiredVersion>
+    <MinimumRequiredVersion>3.4.6.0</MinimumRequiredVersion>
     <CreateWebPageOnPublish>true</CreateWebPageOnPublish>
     <WebPage>publish.htm</WebPage>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>3.4.5.0</ApplicationVersion>
+    <ApplicationVersion>3.4.6.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <CreateDesktopShortcut>true</CreateDesktopShortcut>
     <PublishWizardCompleted>true</PublishWizardCompleted>

--- a/Ana/Content/ChangeLog.cs
+++ b/Ana/Content/ChangeLog.cs
@@ -29,10 +29,8 @@ namespace Ana.Content
         /// </summary>
         public virtual string TransformText()
         {
-            this.Write(@"- Fixes to a hex conversion crash, preventing opening of the settings view
-- Progress bars added for various tasks
-- Moving to .Net Framework 4.6.1, which has improved garbage collection
-- Fixes to potential .NET object collector crash when proxy services unavailable");
+            this.Write("- Hotfix to Label Thresholder - Incorrect bounds settings caused it to be useless" +
+                    ".");
             return this.GenerationEnvironment.ToString();
         }
     }

--- a/Ana/Content/ChangeLog.tt
+++ b/Ana/Content/ChangeLog.tt
@@ -5,7 +5,4 @@
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ import namespace="Ana" #>
-- Fixes to a hex conversion crash, preventing opening of the settings view
-- Progress bars added for various tasks
-- Moving to .Net Framework 4.6.1, which has improved garbage collection
-- Fixes to potential .NET object collector crash when proxy services unavailable
+- Hotfix to Label Thresholder - Incorrect bounds settings caused it to be useless.

--- a/Ana/Properties/AssemblyInfo.cs
+++ b/Ana/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.4.5.0")]
-[assembly: AssemblyFileVersion("3.4.5.0")]
+[assembly: AssemblyVersion("3.4.6.0")]
+[assembly: AssemblyFileVersion("3.4.6.0")]

--- a/Ana/View/LabelThresholder.xaml
+++ b/Ana/View/LabelThresholder.xaml
@@ -67,8 +67,8 @@
                 Height="20"
                 HigherValue="{Binding UpperThreshold}"
                 LowerValue="{Binding LowerThreshold}"
-                Maximum="0"
-                Minimum="100" />
+                Maximum="100"
+                Minimum="0" />
         </Grid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
The XAML autoformatter I am using seems to have swapped the order of the minimum and maximum bounds, so I had mistakenly set them to their opposites.

This is breaking the label thresholder, so this is going to be it's own hotfix release.