### PR TITLE
Task Creation Fixes

### DIFF
--- a/Squalr.Engine.Projects/ProjectItem.cs
+++ b/Squalr.Engine.Projects/ProjectItem.cs
@@ -10,8 +10,6 @@
     using System.IO;
     using System.Runtime.Serialization;
     using System.Runtime.Serialization.Json;
-    using System.Threading;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// A base class for all project items that can be added to the project explorer.
@@ -74,20 +72,7 @@
             this.isActivated = false;
             this.guid = Guid.NewGuid();
             this.ActivationLock = new Object();
-
-            this.RunUpdateLoop();
         }
-
-        private static readonly Type[] KnownTypes =
-        {
-            typeof(ProjectItem),
-            typeof(ScriptItem),
-            typeof(AddressItem),
-            typeof(InstructionItem),
-            typeof(PointerItem),
-            typeof(DotNetItem),
-            typeof(JavaItem),
-        };
 
         public static ProjectItem FromFile(String filePath)
         {
@@ -361,7 +346,7 @@
         }
 
         /// <summary>
-        /// Controls access to activating project items.
+        /// Gets or sets a lock for activating project items.
         /// </summary>
         private Object ActivationLock { get; set; }
 
@@ -378,7 +363,6 @@
             }
 
             this.ActivationLock = new Object();
-            this.RunUpdateLoop();
         }
 
         /// <summary>
@@ -506,22 +490,6 @@
         protected virtual Boolean IsActivatable()
         {
             return true;
-        }
-
-        /// <summary>
-        /// Updates the project item continuously.
-        /// </summary>
-        private void RunUpdateLoop()
-        {
-            Task.Run(() =>
-            {
-                while (true)
-                {
-                    this.Update();
-
-                    Thread.Sleep(50);
-                }
-            });
         }
     }
     //// End class

--- a/Squalr.Engine.Scanning/Scanners/Files/DataSegmentCollector.cs
+++ b/Squalr.Engine.Scanning/Scanners/Files/DataSegmentCollector.cs
@@ -27,7 +27,7 @@
         {
             return TrackableTask<Snapshot>
                 .Create(DataSegmentCollector.Name, out UpdateProgress updateProgress, out CancellationToken cancellationToken)
-                .With(Task.Factory.StartNew<Snapshot>(() =>
+                .With(Task<Snapshot>.Run(() =>
                 {
                     try
                     {

--- a/Squalr.Engine.Scanning/Scanners/ManualScanner.cs
+++ b/Squalr.Engine.Scanning/Scanners/ManualScanner.cs
@@ -35,7 +35,7 @@
         {
             return TrackableTask<Snapshot>
                 .Create(ManualScanner.Name, out UpdateProgress updateProgress, out CancellationToken cancellationToken)
-                .With(Task.Factory.StartNew<Snapshot>(() =>
+                .With(Task<Snapshot>.Run(() =>
                 {
                     Snapshot result = null;
 

--- a/Squalr.Engine.Scanning/Scanners/Pointers/PointerFilter.cs
+++ b/Squalr.Engine.Scanning/Scanners/Pointers/PointerFilter.cs
@@ -31,7 +31,7 @@
         {
             return TrackableTask<Snapshot>
                 .Create(PointerFilter.Name, out UpdateProgress updateProgress, out CancellationToken cancellationToken)
-                .With(Task.Factory.StartNew<Snapshot>(() =>
+                .With(Task<Snapshot>.Run(() =>
                 {
                     try
                     {

--- a/Squalr.Engine.Scanning/Scanners/Pointers/PointerRebase.cs
+++ b/Squalr.Engine.Scanning/Scanners/Pointers/PointerRebase.cs
@@ -35,7 +35,7 @@
         {
             TrackableTask<PointerBag> pointerScanTask = TrackableTask<PointerBag>.Create(PointerRebase.Name, out UpdateProgress updateProgress, out CancellationToken cancellationToken);
 
-            return pointerScanTask.With(Task.Factory.StartNew<PointerBag>(() =>
+            return pointerScanTask.With(Task<PointerBag>.Run(() =>
                 {
                     try
                     {

--- a/Squalr.Engine.Scanning/Scanners/Pointers/PointerRetargetScan.cs
+++ b/Squalr.Engine.Scanning/Scanners/Pointers/PointerRetargetScan.cs
@@ -33,7 +33,7 @@
         {
             TrackableTask<PointerBag> pointerScanTask = TrackableTask<PointerBag>.Create(PointerRetargetScan.Name, out UpdateProgress updateProgress, out CancellationToken cancellationToken);
 
-            return pointerScanTask.With(Task.Factory.StartNew<PointerBag>(() =>
+            return pointerScanTask.With(Task<PointerBag>.Run(() =>
             {
                 try
                 {

--- a/Squalr.Engine.Scanning/Scanners/Pointers/PointerScan.cs
+++ b/Squalr.Engine.Scanning/Scanners/Pointers/PointerScan.cs
@@ -34,72 +34,72 @@ namespace Squalr.Engine.Scanning.Scanners.Pointers
         {
             TrackableTask<PointerBag> pointerScanTask = TrackableTask<PointerBag>.Create(PointerScan.Name, out UpdateProgress updateProgress, out CancellationToken cancellationToken);
 
-            return pointerScanTask.With(Task.Factory.StartNew<PointerBag>(() =>
+            return pointerScanTask.With(Task<PointerBag>.Run(() =>
+            {
+                try
                 {
-                    try
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    PointerSize pointerSize = Processes.Default.IsOpenedProcess32Bit() ? PointerSize.Byte4 : PointerSize.Byte8;
+
+                    Stopwatch stopwatch = new Stopwatch();
+                    stopwatch.Start();
+
+                    // Step 1) Create a snapshot of the target address
+                    Snapshot targetAddress = new Snapshot(new SnapshotRegion[] { new SnapshotRegion(new ReadGroup(address, pointerSize.ToSize(), pointerSize.ToDataType(), alignment), 0, pointerSize.ToSize()) });
+
+                    // Step 2) Collect static pointers
+                    Snapshot staticPointers = SnapshotManager.GetSnapshot(Snapshot.SnapshotRetrievalMode.FromModules, pointerSize.ToDataType());
+                    TrackableTask<Snapshot> valueCollector = ValueCollector.CollectValues(staticPointers);
+                    staticPointers = valueCollector.Result;
+
+                    // Step 3) Collect heap pointers
+                    Snapshot heapPointers = SnapshotManager.GetSnapshot(Snapshot.SnapshotRetrievalMode.FromHeaps, pointerSize.ToDataType());
+                    TrackableTask<Snapshot> heapValueCollector = ValueCollector.CollectValues(heapPointers);
+                    heapPointers = heapValueCollector.Result;
+
+                    // Step 3) Build levels
+                    IList<Level> levels = new List<Level>();
+
+                    if (depth > 0)
                     {
-                        cancellationToken.ThrowIfCancellationRequested();
+                        // Create 1st level with target address and static pointers
+                        levels.Add(new Level(targetAddress, staticPointers));
 
-                        PointerSize pointerSize = Processes.Default.IsOpenedProcess32Bit() ? PointerSize.Byte4 : PointerSize.Byte8;
-
-                        Stopwatch stopwatch = new Stopwatch();
-                        stopwatch.Start();
-
-                        // Step 1) Create a snapshot of the target address
-                        Snapshot targetAddress = new Snapshot(new SnapshotRegion[] { new SnapshotRegion(new ReadGroup(address, pointerSize.ToSize(), pointerSize.ToDataType(), alignment), 0, pointerSize.ToSize()) });
-
-                        // Step 2) Collect static pointers
-                        Snapshot staticPointers = SnapshotManager.GetSnapshot(Snapshot.SnapshotRetrievalMode.FromModules, pointerSize.ToDataType());
-                        TrackableTask<Snapshot> valueCollector = ValueCollector.CollectValues(staticPointers);
-                        staticPointers = valueCollector.Result;
-
-                        // Step 3) Collect heap pointers
-                        Snapshot heapPointers = SnapshotManager.GetSnapshot(Snapshot.SnapshotRetrievalMode.FromHeaps, pointerSize.ToDataType());
-                        TrackableTask<Snapshot> heapValueCollector = ValueCollector.CollectValues(heapPointers);
-                        heapPointers = heapValueCollector.Result;
-
-                        // Step 3) Build levels
-                        IList<Level> levels = new List<Level>();
-
-                        if (depth > 0)
+                        // Initialize each level with all static addresses and all heap addresses
+                        for (Int32 index = 0; index < depth - 1; index++)
                         {
-                            // Create 1st level with target address and static pointers
-                            levels.Add(new Level(targetAddress, staticPointers));
-
-                            // Initialize each level with all static addresses and all heap addresses
-                            for (Int32 index = 0; index < depth - 1; index++)
-                            {
-                                levels.Add(new Level(heapPointers, staticPointers));
-                            }
+                            levels.Add(new Level(heapPointers, staticPointers));
                         }
-
-                        // Exit if canceled
-                        cancellationToken.ThrowIfCancellationRequested();
-
-                        // Step 4) Rebase to filter out unwanted pointers
-                        PointerBag newPointerBag = new PointerBag(levels, maxOffset, pointerSize);
-                        TrackableTask<PointerBag> pointerRebaseTask = PointerRebase.Scan(newPointerBag, readMemory: false, performUnchangedScan: false);
-                        PointerBag rebasedPointerBag = pointerRebaseTask.Result;
-
-                        // Exit if canceled
-                        cancellationToken.ThrowIfCancellationRequested();
-
-                        stopwatch.Stop();
-                        Logger.Log(LogLevel.Info, "Pointer scan complete in: " + stopwatch.Elapsed);
-
-                        return rebasedPointerBag;
-                    }
-                    catch (OperationCanceledException ex)
-                    {
-                        Logger.Log(LogLevel.Warn, "Pointer scan canceled", ex);
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.Log(LogLevel.Error, "Error performing pointer scan", ex);
                     }
 
-                    return null;
-                }, cancellationToken));
+                    // Exit if canceled
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    // Step 4) Rebase to filter out unwanted pointers
+                    PointerBag newPointerBag = new PointerBag(levels, maxOffset, pointerSize);
+                    TrackableTask<PointerBag> pointerRebaseTask = PointerRebase.Scan(newPointerBag, readMemory: false, performUnchangedScan: false);
+                    PointerBag rebasedPointerBag = pointerRebaseTask.Result;
+
+                    // Exit if canceled
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    stopwatch.Stop();
+                    Logger.Log(LogLevel.Info, "Pointer scan complete in: " + stopwatch.Elapsed);
+
+                    return rebasedPointerBag;
+                }
+                catch (OperationCanceledException ex)
+                {
+                    Logger.Log(LogLevel.Warn, "Pointer scan canceled", ex);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log(LogLevel.Error, "Error performing pointer scan", ex);
+                }
+
+                return null;
+            }, cancellationToken));
         }
     }
     //// End class

--- a/Squalr.Engine.Scanning/Scanners/ValueCollector.cs
+++ b/Squalr.Engine.Scanning/Scanners/ValueCollector.cs
@@ -22,7 +22,7 @@
         {
             return TrackableTask<Snapshot>
                 .Create(ValueCollector.Name, out UpdateProgress updateProgress, out CancellationToken cancellationToken)
-                .With(Task.Factory.StartNew<Snapshot>(() =>
+                .With(Task<Snapshot>.Run(() =>
                 {
                     try
                     {

--- a/Squalr.Engine.Scanning/Snapshots/SnapshotManager.cs
+++ b/Squalr.Engine.Scanning/Snapshots/SnapshotManager.cs
@@ -13,9 +13,9 @@
     public static class SnapshotManager
     {
         /// <summary>
-        /// The size limit for snapshots to be saved in the snapshot history (1GB). TODO: Make this a setting.
+        /// The size limit for snapshots to be saved in the snapshot history (256MB). TODO: Make this a setting.
         /// </summary>
-        private const UInt64 SizeLimit = 1UL << 30;
+        private const UInt64 SizeLimit = 1UL << 28;
 
         static SnapshotManager()
         {

--- a/Squalr.Engine/OS/Windows/WindowsProcessInfo.cs
+++ b/Squalr.Engine/OS/Windows/WindowsProcessInfo.cs
@@ -95,7 +95,7 @@
         private static TtlCache<Int32> NoWindowProcessCache = new TtlCache<Int32>(TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(5));
 
         /// <summary>
-        /// Represents an empty icon;
+        /// Represents an empty icon.
         /// </summary>
         private const Icon NoIcon = null;
 

--- a/Squalr/Source/ProjectExplorer/ProjectExplorerViewModel.cs
+++ b/Squalr/Source/ProjectExplorer/ProjectExplorerViewModel.cs
@@ -16,6 +16,7 @@
     using System.IO;
     using System.Linq;
     using System.Threading;
+    using System.Threading.Tasks;
     using System.Windows.Forms;
     using System.Windows.Input;
 
@@ -47,6 +48,7 @@
             this.OpenFileExplorerCommand = new RelayCommand<ProjectItemView>((projectItem) => this.OpenFileExplorer(projectItem), (projectItem) => true);
 
             DockingViewModel.GetInstance().RegisterViewModel(this);
+            this.Update();
         }
 
         /// <summary>
@@ -165,6 +167,24 @@
             {
                 return (this.ProjectRoot != null && (this.ProjectRoot?.Count ?? 0) > 0) ? true : false;
             }
+        }
+
+        /// <summary>
+        /// Runs the update loop, updating all scan results.
+        /// </summary>
+        public void Update()
+        {
+            Task.Run(() =>
+            {
+                while (true)
+                {
+                    ProjectItem projectRoot = this.ProjectRoot?.FirstOrDefault()?.ProjectItem;
+
+                    projectRoot?.Update();
+
+                    Thread.Sleep(50);
+                }
+            });
         }
 
         /// <summary>

--- a/Squalr/Source/Results/ScanResultsViewModel.cs
+++ b/Squalr/Source/Results/ScanResultsViewModel.cs
@@ -89,6 +89,7 @@
 
             SnapshotManager.Subscribe(this);
             DockingViewModel.GetInstance().RegisterViewModel(this);
+            this.Update();
         }
 
         /// <summary>
@@ -375,6 +376,30 @@
             this.ResultCount = snapshot == null ? 0 : snapshot.ElementCount;
             this.ByteCount = snapshot == null ? 0 : snapshot.ByteCount;
             this.CurrentPage = 0;
+        }
+
+        /// <summary>
+        /// Runs the update loop, updating all scan results.
+        /// </summary>
+        public void Update()
+        {
+            Task.Run(() =>
+            {
+                while (true)
+                {
+                    IList<ScanResult> scanResults = this.Addresses?.ToList();
+
+                    if (scanResults != null)
+                    {
+                        foreach (ScanResult result in scanResults)
+                        {
+                            result?.PointerItem.Update();
+                        }
+                    }
+
+                    Thread.Sleep(50);
+                }
+            });
         }
 
         /// <summary>

--- a/Squalr/Source/Scanners/ValueCollectorViewModel.cs
+++ b/Squalr/Source/Scanners/ValueCollectorViewModel.cs
@@ -10,6 +10,7 @@
     using Squalr.Source.Tasks;
     using System;
     using System.Threading;
+    using System.Threading.Tasks;
     using System.Windows.Input;
 
     /// <summary>
@@ -29,7 +30,7 @@
         /// </summary>
         public ValueCollectorViewModel()
         {
-            this.CollectValuesCommand = new RelayCommand(() => this.CollectValues(), () => true);
+            this.CollectValuesCommand = new RelayCommand(() => Task.Run(() => this.CollectValues()), () => true);
         }
 
         /// <summary>

--- a/Squalr/Source/Updater/ApplicationUpdater.cs
+++ b/Squalr/Source/Updater/ApplicationUpdater.cs
@@ -52,7 +52,7 @@
 
                         TrackableTask<Boolean> downloadTask = TrackableTask<Boolean>
                             .Create("Downloading Updates", out UpdateProgress updateProgress, out CancellationToken cancellationToken)
-                            .With(Task.Factory.StartNew<Boolean>(() =>
+                            .With(Task<Boolean>.Run(() =>
                             {
                                 try
                                 {
@@ -76,7 +76,7 @@
 
                         TrackableTask<Boolean> applyReleasesTask = TrackableTask<Boolean>
                             .Create("Applying Releases", out updateProgress, out cancellationToken)
-                            .With(Task.Factory.StartNew<Boolean>(() =>
+                            .With(Task<Boolean>.Run(() =>
                             {
                                 try
                                 {
@@ -100,7 +100,7 @@
 
                         TrackableTask<Boolean> updateTask = TrackableTask<Boolean>
                             .Create("Updating", out updateProgress, out cancellationToken)
-                            .With(Task.Factory.StartNew<Boolean>(() =>
+                            .With(Task<Boolean>.Run(() =>
                             {
                                 try
                                 {

--- a/Squalr/View/MainWindow.xaml
+++ b/Squalr/View/MainWindow.xaml
@@ -153,8 +153,8 @@
                         Header="File">
                         <shell:MenuItem
                             BorderThickness="0"
-                            Command="{Binding ProjectExplorerViewModel.OpenProjectCommand}"
-                            Header="Open"
+                            Command="{Binding ProjectExplorerViewModel.SelectProjectCommand}"
+                            Header="Select Project"
                             Style="{Binding}" />
                         <shell:MenuItem
                             BorderThickness="0"


### PR DESCRIPTION
- Using Task.Run instead of Factory.StartNew (Run is apparently shorthand & better practice for our use cases)
- Project items are no longer self updating. This was causing too many threads to be created and exhausting the thread pool. This has been offloaded to the project explorer / scan results to update their own items